### PR TITLE
For Github issue

### DIFF
--- a/Notebook/Issue.md
+++ b/Notebook/Issue.md
@@ -1,0 +1,15 @@
+# The issue
+
+- Getting the message "Sorry, something went wrong. Reload?" when viewing an *.ipynb on a GitHub blob page.
+```diff
++ Probably a problem with the GitHub notebook viewing tool - sometimes github fails to render the ipynb notebooks, I believe that is some temporary (and recurring) issue with their backend
+A workaround
+
++ Try to open that notebook that you want using nbviewer online, you don't need to install it.
+```
+### Open "https://nbviewer.jupyter.org/"
+### Paste this link - https://github.com/shuklasaharsh/IOT_Temperatur_ESP8266/blob/main/Notebook/Time%20predictor%20backend.ipynb
+
+```diff
++ The Notebook should be visible.
+```


### PR DESCRIPTION
The GitHub notebook visualiser is not working for a while and it is mainly a backend issue, This is a workaround for that, to view the files elsewhere